### PR TITLE
Jatie

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shoppin_and_go/screens/loading_screen.dart';
+import 'package:shoppin_and_go/screens/register_screen.dart';
 import 'package:shoppin_and_go/screens/qr_scan_screen.dart';
 import 'package:shoppin_and_go/screens/cart_screen.dart';
 
@@ -17,9 +18,9 @@ class MyApp extends StatelessWidget {
       home: const LoadingScreen(),
       debugShowCheckedModeBanner: false,
       routes: {
-        '/qr_scan': (context) => const QRScanScreen(),
+        '/register': (context) => const RegisterScreen(),
+        '/scanner': (context) => const QRScanScreen(),
         '/cart': (context) => const CartScreen(),
-        '/scanner': (context) => const QRScanner(),
       },
     );
   }

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -5,8 +5,13 @@ class CartScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
+    final String cartId = ModalRoute.of(context)!.settings.arguments as String;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(cartId),
+      ),
+      body: const Center(
         child: Text("장바구니"),
       ),
     );

--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -21,7 +21,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
             ElevatedButton(
               child: const Text('시작하기'),
               onPressed: () {
-                Navigator.pushNamed(context, '/qr_scan');
+                Navigator.pushNamed(context, '/register');
               },
             ),
           ],

--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -21,9 +21,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
             ElevatedButton(
               child: const Text('시작하기'),
               onPressed: () {
-                // Navigator.pushNamed(context, '/qr_scan');
-                // Navigator.pushNamed(context, '/scanner');
-                _navigateAndDisplaySelection(context);
+                Navigator.pushNamed(context, '/qr_scan');
               },
             ),
           ],
@@ -31,16 +29,4 @@ class _LoadingScreenState extends State<LoadingScreen> {
       ),
     );
   }
-}
-
-// pop 된 qr code SnackBar 로 띄워주기
-Future<void> _navigateAndDisplaySelection(BuildContext context) async {
-  // Navigator.push returns a Future that completes after calling
-  // Navigator.pop on the Selection Screen.
-  final result = await Navigator.pushNamed(context, '/qr_scan');
-
-  if (!context.mounted) return;
-  ScaffoldMessenger.of(context)
-    ..removeCurrentSnackBar()
-    ..showSnackBar(SnackBar(content: Text('$result')));
 }

--- a/lib/screens/qr_scan_screen.dart
+++ b/lib/screens/qr_scan_screen.dart
@@ -19,8 +19,7 @@ class QRScanScreen extends StatelessWidget {
                 ElevatedButton(
                   child: const Text('스캔 시작'),
                   onPressed: () {
-                    // Navigator.pushNamed(context, '/cart');
-                    Navigator.pushNamed(context, '/scanner');
+                    _navigateAndDisplaySelection(context);
                   },
                 ),
               ],
@@ -32,7 +31,6 @@ class QRScanScreen extends StatelessWidget {
                   child: const Text('카트 확인'),
                   onPressed: () {
                     Navigator.pushNamed(context, '/cart');
-                    // Navigator.pushNamed(context, '/scanner');
                   },
                 )
               ],
@@ -42,6 +40,18 @@ class QRScanScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+// pop 된 qr code SnackBar 로 띄워주기
+Future<void> _navigateAndDisplaySelection(BuildContext context) async {
+  // Navigator.push returns a Future that completes after calling
+  // Navigator.pop on the Selection Screen.
+  final result = await Navigator.pushNamed(context, '/scanner');
+
+  if (!context.mounted) return;
+  ScaffoldMessenger.of(context)
+    ..removeCurrentSnackBar()
+    ..showSnackBar(SnackBar(content: Text('$result')));
 }
 
 //qr 스캐너 클래스
@@ -118,8 +128,6 @@ class _QRScannerState extends State<QRScanner> {
 
       setState(() {
         result = scanData; // 스캔된 데이터를 담는다.
-        print('barcode_result----------------');
-        print(result!.code);
 
         // result를 다시 url로 담는다.
         String url = result!.code.toString();

--- a/lib/screens/qr_scan_screen.dart
+++ b/lib/screens/qr_scan_screen.dart
@@ -13,27 +13,12 @@ class QRScanScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Column(
-              children: [
-                const Text("QR 스캔"),
-                ElevatedButton(
-                  child: const Text('스캔 시작'),
-                  onPressed: () {
-                    _navigateAndDisplaySelection(context);
-                  },
-                ),
-              ],
-            ),
-            Column(
-              children: [
-                const Text("카트 정보 보기"),
-                ElevatedButton(
-                  child: const Text('카트 확인'),
-                  onPressed: () {
-                    Navigator.pushNamed(context, '/cart');
-                  },
-                )
-              ],
+            const Text("QR 스캔"),
+            ElevatedButton(
+              child: const Text('스캔 시작'),
+              onPressed: () {
+                _navigateToScannerAndCart(context);
+              },
             ),
           ],
         ),
@@ -43,15 +28,19 @@ class QRScanScreen extends StatelessWidget {
 }
 
 // pop 된 qr code SnackBar 로 띄워주기
-Future<void> _navigateAndDisplaySelection(BuildContext context) async {
+Future<void> _navigateToScannerAndCart(BuildContext context) async {
   // Navigator.push returns a Future that completes after calling
   // Navigator.pop on the Selection Screen.
   final result = await Navigator.pushNamed(context, '/scanner');
 
   if (!context.mounted) return;
-  ScaffoldMessenger.of(context)
-    ..removeCurrentSnackBar()
-    ..showSnackBar(SnackBar(content: Text('$result')));
+  if (result != null) {
+    // QR 스캔 결과가 있어야 snackbar를 띄우고 카트 화면으로 이동
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('$result')));
+    Navigator.pushNamed(context, '/cart', arguments: result);
+  }
 }
 
 //qr 스캐너 클래스

--- a/lib/screens/qr_scan_screen.dart
+++ b/lib/screens/qr_scan_screen.dart
@@ -1,74 +1,15 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 
-class QRScanScreen extends StatelessWidget {
+class QRScanScreen extends StatefulWidget {
   const QRScanScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              onPressed: () {
-                _navigateToScannerAndCart(context);
-              },
-              style: ElevatedButton.styleFrom(
-                shape: const CircleBorder(),
-                padding: const EdgeInsets.all(24),
-                backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
-                elevation: 8,
-                shadowColor: Colors.black,
-              ),
-              child: const Icon(
-                Icons.qr_code_scanner,
-                size: 84,
-                color: Colors.white,
-              ),
-            ),
-            const SizedBox(height: 40),
-            const Text(
-              "카트를 등록하세요",
-              style: TextStyle(
-                fontSize: 20,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  State<StatefulWidget> createState() => _QRScanScreenState();
 }
 
-// pop 된 qr code SnackBar 로 띄워주기
-Future<void> _navigateToScannerAndCart(BuildContext context) async {
-  // Navigator.push returns a Future that completes after calling
-  // Navigator.pop on the Selection Screen.
-  final result = await Navigator.pushNamed(context, '/scanner');
-
-  if (!context.mounted) return;
-  if (result != null) {
-    // QR 스캔 결과가 있어야 snackbar를 띄우고 카트 화면으로 이동
-    ScaffoldMessenger.of(context)
-      ..removeCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text('$result')));
-    Navigator.pushNamed(context, '/cart', arguments: result);
-  }
-}
-
-//qr 스캐너 클래스
-class QRScanner extends StatefulWidget {
-  const QRScanner({super.key});
-
-  @override
-  State<StatefulWidget> createState() => _QRScannerState();
-}
-
-class _QRScannerState extends State<QRScanner> {
+class _QRScanScreenState extends State<QRScanScreen> {
   Barcode? result;
   QRViewController? controller;
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');

--- a/lib/screens/qr_scan_screen.dart
+++ b/lib/screens/qr_scan_screen.dart
@@ -13,12 +13,29 @@ class QRScanScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text("QR 스캔"),
             ElevatedButton(
-              child: const Text('스캔 시작'),
               onPressed: () {
                 _navigateToScannerAndCart(context);
               },
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(24),
+                backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
+                elevation: 8,
+                shadowColor: Colors.black,
+              ),
+              child: const Icon(
+                Icons.qr_code_scanner,
+                size: 84,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 40),
+            const Text(
+              "카트를 등록하세요",
+              style: TextStyle(
+                fontSize: 20,
+              ),
             ),
           ],
         ),

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class RegisterScreen extends StatelessWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                _navigateToScannerAndCart(context);
+              },
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(24),
+                backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
+                elevation: 8,
+                shadowColor: Colors.black,
+              ),
+              child: const Icon(
+                Icons.qr_code_scanner,
+                size: 84,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 40),
+            const Text(
+              "카트를 등록하세요",
+              style: TextStyle(
+                fontSize: 20,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// pop 된 qr code SnackBar 로 띄워주기
+Future<void> _navigateToScannerAndCart(BuildContext context) async {
+  // Navigator.push returns a Future that completes after calling
+  // Navigator.pop on the Selection Screen.
+  final result = await Navigator.pushNamed(context, '/scanner');
+
+  if (!context.mounted) return;
+  if (result != null) {
+    // QR 스캔 결과가 있어야 snackbar를 띄우고 카트 화면으로 이동
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('$result')));
+    Navigator.pushNamed(context, '/cart', arguments: result);
+  }
+}


### PR DESCRIPTION
커밋 내역에 자세히 작성해놨습니다. 참고해 주세요

1. qr결과값을 표시하는 snackBar가 홈화면에서 표시되는 문제 수정
2. qr이 결과값을 안 뱉어도 sncakBar가 나오는 문제 수정
3. qr이 결과값을 제대로 뱉으면 카트화면으로 이동
4. 카트 등록화면 디자인 적용
5. 카트화면에서 qr코드 결과값 사용하도록 수정
6. 기존 QRScanScreen과 새로 만드신 QRScanner의 이름이 애매하여 이름 수정
    QRScanner를 QRScanScreen으로 바꾸며 별도의 파일로 분리, 기존 QRScanScreen은 RegisterScreen이 됨

그리고 카메라 권한을 주지 않았을 때, snackBar가 무한히(?) 나오는 이슈가 있습니다. 권한이 없으면 진입(또는 사용)을 거부하고, 카메라를 다시 사용하길 원하면 그 때 다시 권한을 또 요청하는 정확한 알고리즘이 필요하다고 생각합니다.