### PR TITLE
payment & receipt

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:shoppin_and_go/screens/loading_screen.dart';
+import 'package:shoppin_and_go/screens/reciept_screen.dart';
 import 'package:shoppin_and_go/screens/register_screen.dart';
 import 'package:shoppin_and_go/screens/qr_scan_screen.dart';
 import 'package:shoppin_and_go/screens/cart_screen.dart';
+import 'package:shoppin_and_go/screens/payment_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -21,6 +23,8 @@ class MyApp extends StatelessWidget {
         '/register': (context) => const RegisterScreen(),
         '/scanner': (context) => const QRScanScreen(),
         '/cart': (context) => const CartScreen(),
+        '/payment': (context) => const PaymentScreen(),
+        '/receipt': (context) => const ReceiptScreen(),
       },
     );
   }

--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -24,6 +24,11 @@ class _LoadingScreenState extends State<LoadingScreen> {
                 Navigator.pushNamed(context, '/register');
               },
             ),
+            ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/payment');
+                },
+                child: const Text('결제화면 보기'))
           ],
         ),
       ),

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class PaymentScreen extends StatelessWidget {
+  const PaymentScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<String> cards = [
+      '1번 카드',
+      '2번 카드',
+      '3번 카드',
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('결제하기'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            // 총 금액 표시
+            const Text(
+              '총 금액: ₩50,000', // 장바구니에서 받아와서 수정할 부분
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            // 카드 선택 캐로셀
+            SizedBox(
+              height: 120,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: cards.length,
+                itemBuilder: (context, index) {
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Container(
+                      width: 200,
+                      padding: const EdgeInsets.all(16.0),
+                      child: Center(
+                        child: Text(
+                          cards[index],
+                          style: const TextStyle(fontSize: 18),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            // 결제하기 버튼
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushNamed(context, '/receipt'); // 영수증 화면으로 전환
+              },
+              style: ElevatedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
+              ),
+              child: const Text(
+                '결제하기',
+                style: TextStyle(fontSize: 20),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/reciept_screen.dart
+++ b/lib/screens/reciept_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+class ReceiptScreen extends StatelessWidget {
+  const ReceiptScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // 결제 금액 및 내역 예시 데이터
+    const double totalAmount = 50000.0; // Example amount
+    final List<Map<String, dynamic>> purchaseItems = [
+      {'name': 'Item 1', 'quantity': 2, 'price': 15000.0},
+      {'name': 'Item 2', 'quantity': 1, 'price': 20000.0},
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('결제 완료'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '결제 내역',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16.0),
+            Expanded(
+              child: ListView.builder(
+                itemCount: purchaseItems.length,
+                itemBuilder: (context, index) {
+                  final item = purchaseItems[index];
+                  return ListTile(
+                    title: Text(item['name']),
+                    subtitle: Text('수량: ${item['quantity']}'),
+                    trailing: Text(
+                      '₩${item['price'].toStringAsFixed(0)}',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const Divider(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '총 결제 금액',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  '₩${totalAmount.toStringAsFixed(0)}',
+                  style: const TextStyle(
+                      fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24.0),
+            Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/register'); // 결제 완료 후 돌아가기
+                },
+                style: ElevatedButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
+                ),
+                child: const Text('확인', style: TextStyle(fontSize: 18)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
main.dart
내비게이션 루트 추가 : /payment, /receipt

loading_screen.dart
아직 장바구니 화면이 없어서 결제 화면으로 넘어갈 수 있는 버튼 추가 (추후 삭제 예정)

payment_screen.dart
3개의 카드 있다고 가정해 화면 구성
결제 버튼 누르면 receipt 화면으로 넘어가도록 함
ui 가 미흡하여 추후에 수정

receipt_screen.dart
임의로 결제내역을 구성하여 구현 (추후 서버 연결 후 수정)
결제 내역에서 상품의 종류와 수량 ,금액 표시
총 금액 표시
확인 버튼 눌렀을 때 RegistierScreen 으로 가도록 함