### PR TITLE
Hwun

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:shoppin_and_go/screens/loading_screen.dart';
+import 'package:shoppin_and_go/screens/receipt_screen.dart';
 import 'package:shoppin_and_go/screens/register_screen.dart';
 import 'package:shoppin_and_go/screens/qr_scan_screen.dart';
 import 'package:shoppin_and_go/screens/cart_screen.dart';
+import 'package:shoppin_and_go/screens/payment_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -21,6 +23,8 @@ class MyApp extends StatelessWidget {
         '/register': (context) => const RegisterScreen(),
         '/scanner': (context) => const QRScanScreen(),
         '/cart': (context) => const CartScreen(),
+        '/payment': (context) => const PaymentScreen(),
+        '/receipt': (context) => const ReceiptScreen(),
       },
     );
   }

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -9,36 +9,53 @@ class CartScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final String cartId = ModalRoute.of(context)!.settings.arguments as String;
 
+    // CartItem 목록 생성
+    final List<CartItem> cartItems = [
+      const CartItem(
+        name: '펩시',
+        price: '1600',
+        count: '1',
+        imagePath: 'assets/pepsi.png',
+      ),
+      const CartItem(
+        name: '콘칩',
+        price: '1500',
+        count: '2',
+        imagePath: 'assets/cornchip.png',
+      ),
+    ];
+
+    // 장바구니 아이템 데이터를 ReceiptScreen에 전달할 수 있도록 Map 형식으로 변환
+    final List<Map<String, dynamic>> cartItemData = cartItems
+        .map((item) => {
+              'name': item.name,
+              'price': int.parse(item.price),
+              'quantity': int.parse(item.count),
+              'imagePath': item.imagePath,
+            })
+        .toList();
+
+    // 총 금액 계산
+    final int totalAmount = cartItemData.fold(
+      0,
+      (sum, item) => (sum + (item['price'] * item["quantity"])).toInt(),
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: Text(cartId),
       ),
-      body: ListView(
-        children: const [
-          CartItem(
-            name: '펩시',
-            price: '1,600',
-            count: '1',
-            imagePath: 'assets/pepsi.png',
-          ),
-          CartItem(
-            name: '콘칩',
-            price: '1,500',
-            count: '1',
-            imagePath: 'assets/cornchip.png',
-          ),
-        ],
-      ),
+      body: ListView(children: cartItems),
       bottomNavigationBar: SizedBox(
         height: 150,
         child: Column(
           children: [
-            const Padding(
-              padding: EdgeInsets.all(16.0),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
+                  const Text(
                     '총 금액',
                     style: TextStyle(
                       fontSize: 14,
@@ -46,8 +63,8 @@ class CartScreen extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    '₩3,100',
-                    style: TextStyle(
+                    '₩${totalAmount.toString()}',
+                    style: const TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
                       color: Colors.red,
@@ -76,7 +93,12 @@ class CartScreen extends StatelessWidget {
                 sliderRotate: false,
                 sliderButtonYOffset: -40,
                 onSubmit: () {
-                  // Navigator.pushNamed(context, '/payment');
+                  // 결제 화면에 cartItemData 전달
+                  Navigator.pushNamed(
+                    context,
+                    '/payment',
+                    arguments: cartItemData,
+                  );
                   return;
                 },
               ),

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+class PaymentScreen extends StatefulWidget {
+  const PaymentScreen({super.key});
+
+  @override
+  _PaymentScreenState createState() => _PaymentScreenState();
+}
+
+class _PaymentScreenState extends State<PaymentScreen> {
+  // 선택된 카드 인덱스를 추적하기 위한 변수
+  int selectedCardIndex = -1;
+
+  @override
+  Widget build(BuildContext context) {
+    // CartScreen에서 전달된 cartItems 받기
+    final List<Map<String, dynamic>> cartItems = ModalRoute.of(context)!
+        .settings
+        .arguments as List<Map<String, dynamic>>;
+
+    // 총 금액 계산
+    final int totalAmount = cartItems.fold(
+      0,
+      (sum, item) => (sum + (item['price'] * item['quantity'])).toInt(),
+    );
+
+    final List<String> cards = [
+      '1번 카드',
+      '2번 카드',
+      '3번 카드',
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('결제하기'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            // 총 금액 표시
+            Text(
+              '총 금액: ₩$totalAmount', // 계산된 총 금액 표시
+              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            // 카드 선택 캐로셀
+            SizedBox(
+              height: 120,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: cards.length,
+                itemBuilder: (context, index) {
+                  // 카드가 선택되면 활성화 스타일 적용
+                  final bool isSelected = index == selectedCardIndex;
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        selectedCardIndex = index;
+                      });
+                    },
+                    child: Card(
+                      margin: const EdgeInsets.symmetric(horizontal: 8.0),
+                      color: isSelected
+                          ? Colors.greenAccent // 활성화된 카드 색상
+                          : Colors.white, // 비활성화된 카드 색상
+                      child: Container(
+                        width: 200,
+                        padding: const EdgeInsets.all(16.0),
+                        child: Center(
+                          child: Text(
+                            cards[index],
+                            style: TextStyle(
+                              fontSize: 18,
+                              color: isSelected ? Colors.white : Colors.black,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            ElevatedButton(
+              onPressed: selectedCardIndex != -1
+                  ? () => _showConfirmationDialog(
+                      context, cards[selectedCardIndex], cartItems)
+                  : null, // 카드가 선택되지 않으면 버튼 비활성화
+              style: ElevatedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
+                backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
+              ),
+              child: const Text(
+                '결제하기',
+                style: TextStyle(
+                    fontSize: 20, color: Color.fromRGBO(255, 255, 255, 1)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 결제 확인 다이얼로그
+  void _showConfirmationDialog(BuildContext context, String selectedCard,
+      List<Map<String, dynamic>> cartItems) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("결제 확인"),
+          content: Text("$selectedCard로 결제하시겠습니까?"),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text("취소"),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(
+                  context,
+                  '/receipt',
+                  arguments: cartItems, // cartItems 전달
+                );
+              },
+              child: const Text("확인"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,3 +1,5 @@
+// PaymentScreen.dart
+
 import 'package:flutter/material.dart';
 
 class PaymentScreen extends StatefulWidget {
@@ -41,7 +43,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
           children: [
             // 총 금액 표시
             Text(
-              '총 금액: ₩$totalAmount', // 계산된 총 금액 표시
+              '총 금액: ₩$totalAmount',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             // 카드 선택 캐로셀
@@ -61,9 +63,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
                     },
                     child: Card(
                       margin: const EdgeInsets.symmetric(horizontal: 8.0),
-                      color: isSelected
-                          ? Colors.greenAccent // 활성화된 카드 색상
-                          : Colors.white, // 비활성화된 카드 색상
+                      color: isSelected ? Colors.greenAccent : Colors.white,
                       child: Container(
                         width: 200,
                         padding: const EdgeInsets.all(16.0),
@@ -86,7 +86,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
               onPressed: selectedCardIndex != -1
                   ? () => _showConfirmationDialog(
                       context, cards[selectedCardIndex], cartItems)
-                  : null, // 카드가 선택되지 않으면 버튼 비활성화
+                  : null,
               style: ElevatedButton.styleFrom(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
@@ -123,10 +123,14 @@ class _PaymentScreenState extends State<PaymentScreen> {
             TextButton(
               onPressed: () {
                 Navigator.pop(context);
-                Navigator.pushNamed(
+
+                Navigator.pushReplacementNamed(
                   context,
                   '/receipt',
-                  arguments: cartItems, // cartItems 전달
+                  arguments: {
+                    'cartItems': cartItems,
+                    'selectedCard': selectedCard,
+                  }, // 선택된 카드와 cartItems 전달
                 );
               },
               child: const Text("확인"),

--- a/lib/screens/payment_screen.dart
+++ b/lib/screens/payment_screen.dart
@@ -1,6 +1,5 @@
-// PaymentScreen.dart
-
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class PaymentScreen extends StatefulWidget {
   const PaymentScreen({super.key});
@@ -10,8 +9,7 @@ class PaymentScreen extends StatefulWidget {
 }
 
 class _PaymentScreenState extends State<PaymentScreen> {
-  // 선택된 카드 인덱스를 추적하기 위한 변수
-  int selectedCardIndex = -1;
+  int selectedCardIndex = -1; // 선택된 카드 인덱스를 추적하는 변수
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +21,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
     // 총 금액 계산
     final int totalAmount = cartItems.fold(
       0,
-      (sum, item) => (sum + (item['price'] * item['quantity'])).toInt(),
+      (sum, item) => sum + ((item['price'] as int) * (item['quantity'] as int)),
     );
 
     final List<String> cards = [
@@ -32,6 +30,9 @@ class _PaymentScreenState extends State<PaymentScreen> {
       '3번 카드',
     ];
 
+    // 가격 표시 형식을 위한 NumberFormat 설정 (천 단위 쉼표 추가)
+    final NumberFormat currencyFormat = NumberFormat('#,##0', 'ko_KR');
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('결제하기'),
@@ -39,13 +40,58 @@ class _PaymentScreenState extends State<PaymentScreen> {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: [
             // 총 금액 표시
             Text(
-              '총 금액: ₩$totalAmount',
+              '총 금액: ₩${currencyFormat.format(totalAmount)}',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
+            const SizedBox(height: 16.0),
+            // 상품 리스트
+            Expanded(
+              child: ListView.builder(
+                itemCount: cartItems.length,
+                itemBuilder: (context, index) {
+                  final item = cartItems[index];
+                  return Card(
+                    margin: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: ListTile(
+                      // 상품 이미지가 null인 경우 기본 이미지 경로를 사용
+                      leading: Image.asset(
+                        item['imagePath'] ?? 'assets/default.png', // 기본 이미지 경로
+                        width: 50,
+                        height: 50,
+                        fit: BoxFit.cover,
+                      ),
+                      title: Text(item['name'] ??
+                          '상품 이름 없음'), // 상품 이름이 null인 경우 기본 텍스트 표시
+                      subtitle: Text(
+                          '수량: ${item['quantity'] ?? 0}'), // 수량이 null인 경우 0으로 표시
+                      trailing: Text(
+                        // 천 단위 쉼표가 포함된 가격 표시
+                        '₩${currencyFormat.format((item['price'] as int) * (item['quantity'] as int))}',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16.0),
+            // 안내 문구
+            const Text(
+              '상품을 추가 / 제거하려면 뒤로 이동하세요',
+              style: TextStyle(fontSize: 14, color: Colors.black54),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16.0),
+            // 카드 선택 제목
+            const Text(
+              '카드 선택',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8.0),
             // 카드 선택 캐로셀
             SizedBox(
               height: 120,
@@ -53,7 +99,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 scrollDirection: Axis.horizontal,
                 itemCount: cards.length,
                 itemBuilder: (context, index) {
-                  // 카드가 선택되면 활성화 스타일 적용
+                  // 카드가 선택되면 스타일 적용
                   final bool isSelected = index == selectedCardIndex;
                   return GestureDetector(
                     onTap: () {
@@ -63,7 +109,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
                     },
                     child: Card(
                       margin: const EdgeInsets.symmetric(horizontal: 8.0),
-                      color: isSelected ? Colors.greenAccent : Colors.white,
+                      color: isSelected ? Colors.pinkAccent[400] : Colors.white,
                       child: Container(
                         width: 200,
                         padding: const EdgeInsets.all(16.0),
@@ -82,6 +128,8 @@ class _PaymentScreenState extends State<PaymentScreen> {
                 },
               ),
             ),
+            const SizedBox(height: 16.0),
+            // 결제하기 버튼 (카드가 선택되지 않으면 비활성화)
             ElevatedButton(
               onPressed: selectedCardIndex != -1
                   ? () => _showConfirmationDialog(
@@ -116,21 +164,21 @@ class _PaymentScreenState extends State<PaymentScreen> {
           actions: <Widget>[
             TextButton(
               onPressed: () {
-                Navigator.pop(context);
+                Navigator.pop(context); // 다이얼로그 닫기
               },
               child: const Text("취소"),
             ),
             TextButton(
               onPressed: () {
-                Navigator.pop(context);
-
+                Navigator.pop(context); // 다이얼로그 닫기
+                // 결제 완료 후 영수증 화면으로 이동
                 Navigator.pushReplacementNamed(
                   context,
                   '/receipt',
                   arguments: {
                     'cartItems': cartItems,
                     'selectedCard': selectedCard,
-                  }, // 선택된 카드와 cartItems 전달
+                  },
                 );
               },
               child: const Text("확인"),

--- a/lib/screens/receipt_screen.dart
+++ b/lib/screens/receipt_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+class ReceiptScreen extends StatelessWidget {
+  const ReceiptScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // PaymentScreen에서 전달된 cartItems 받기
+    final List<Map<String, dynamic>> cartItems = ModalRoute.of(context)!
+        .settings
+        .arguments as List<Map<String, dynamic>>;
+    final double totalAmount = cartItems.fold(
+        0, (sum, item) => sum + (item['price'] * item['quantity']));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('결제 완료'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '결제 내역',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16.0),
+            Expanded(
+              child: ListView.builder(
+                itemCount: cartItems.length,
+                itemBuilder: (context, index) {
+                  final item = cartItems[index];
+                  return ListTile(
+                    title: Text(item['name']),
+                    subtitle: Text('수량: ${item['quantity']}'),
+                    trailing: Text(
+                      '₩${(item['price'] * item['quantity']).toStringAsFixed(0)}',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const Divider(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '총 결제 금액',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  '₩${totalAmount.toStringAsFixed(0)}',
+                  style: const TextStyle(
+                      fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24.0),
+            Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/register'); // 결제 완료 후 돌아가기
+                },
+                style: ElevatedButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
+                  backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
+                ),
+                child: const Text('확인',
+                    style: TextStyle(
+                        fontSize: 18, color: Color.fromRGBO(255, 255, 255, 1))),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/receipt_screen.dart
+++ b/lib/screens/receipt_screen.dart
@@ -1,79 +1,110 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class ReceiptScreen extends StatelessWidget {
   const ReceiptScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // PaymentScreen에서 전달된 cartItems 받기
-    final List<Map<String, dynamic>> cartItems = ModalRoute.of(context)!
-        .settings
-        .arguments as List<Map<String, dynamic>>;
+    // PaymentScreen에서 전달된 arguments 가져오기
+    final Map<String, dynamic> args =
+        ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
+    final List<Map<String, dynamic>> cartItems = args['cartItems']; // 장바구니 항목
+    final String selectedCard = args['selectedCard']; // 선택된 카드 정보
+
+    // 총 결제 금액 계산
     final double totalAmount = cartItems.fold(
         0, (sum, item) => sum + (item['price'] * item['quantity']));
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('결제 완료'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              '결제 내역',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 16.0),
-            Expanded(
-              child: ListView.builder(
-                itemCount: cartItems.length,
-                itemBuilder: (context, index) {
-                  final item = cartItems[index];
-                  return ListTile(
-                    title: Text(item['name']),
-                    subtitle: Text('수량: ${item['quantity']}'),
-                    trailing: Text(
-                      '₩${(item['price'] * item['quantity']).toStringAsFixed(0)}',
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  );
-                },
+    // 현재 날짜와 시간을 지정된 형식으로 가져오기
+    final String purchaseDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    final String purchaseTime = DateFormat('HH:mm').format(DateTime.now());
+    const String purchaseLocation = '이마트 자양점'; // 구매 장소
+
+    return WillPopScope(
+      // 뒤로 가기 및 스와이프 동작을 비활성화
+      onWillPop: () async => false,
+      child: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 80, 16, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 구매 장소를 화면 상단에 중앙 정렬하여 표시
+              const Center(
+                child: Text(
+                  purchaseLocation,
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
               ),
-            ),
-            const Divider(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text(
-                  '총 결제 금액',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              const SizedBox(height: 16.0),
+              const Divider(),
+              // 구매 날짜와 시간, 결제 카드 정보를 표시
+              Text('구매 날짜: $purchaseDate'),
+              Text('구매 시간: $purchaseTime'),
+              Text('결제 카드: $selectedCard'),
+              const Divider(),
+              const SizedBox(height: 16.0),
+              // '구매 내역' 제목 표시
+              const Text(
+                '구매 내역',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              // 장바구니 항목 목록을 생성하는 ListView.builder
+              Expanded(
+                child: ListView.builder(
+                  itemCount: cartItems.length, // 항목 개수
+                  itemBuilder: (context, index) {
+                    final item = cartItems[index];
+                    return ListTile(
+                      title: Text(item['name']), // 항목 이름
+                      subtitle: Text('수량: ${item['quantity']}'), // 항목 수량
+                      trailing: Text(
+                        // 항목 가격 표시
+                        '₩${(item['price'] * item['quantity']).toStringAsFixed(0)}',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    );
+                  },
                 ),
-                Text(
-                  '₩${totalAmount.toStringAsFixed(0)}',
-                  style: const TextStyle(
-                      fontSize: 18, fontWeight: FontWeight.bold),
-                ),
-              ],
-            ),
-            const SizedBox(height: 24.0),
-            Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/register'); // 결제 완료 후 돌아가기
-                },
-                style: ElevatedButton.styleFrom(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 80, vertical: 16),
-                  backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
-                ),
-                child: const Text('확인',
+              ),
+              const Divider(),
+              // 총 결제 금액을 화면 하단에 표시
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    '총 결제 금액',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  Text(
+                    '₩${totalAmount.toStringAsFixed(0)}',
+                    style: const TextStyle(
+                        fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24.0),
+              // 확인 버튼 (클릭 시 '/register' 화면으로 이동)
+              Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/register');
+                  },
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 80, vertical: 16),
+                    backgroundColor: const Color.fromRGBO(0xDB, 0x1E, 0x17, 1),
+                  ),
+                  child: const Text(
+                    '확인',
                     style: TextStyle(
-                        fontSize: 18, color: Color.fromRGBO(255, 255, 255, 1))),
+                        fontSize: 18, color: Color.fromRGBO(255, 255, 255, 1)),
+                  ),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/reciept_screen.dart
+++ b/lib/screens/reciept_screen.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -80,6 +80,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   permission_handler : ^11.3.1
   slide_to_act: ^2.0.2
-
+  intl: ^0.17.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
PR #8

main
route 추가

cart_screen
다른 페이지에서도 재활용할 수 있도록 Map으로 수정
총 금액도 아이템들 가격의 합으로 수정

payment_screen
cart_screen 에서 받아온 정보를 가지고 총 금액 띄워줌
카드 캐로셀 만들어서 선택할 수 있도록 함
카드가 선택될 때에만 결제 버튼 활성화
결제버튼 누르면 다이얼로그 띄워서 재확인

receipt_screen
payment_screen 에서 받아온 장바구니 정보로 상품 수량과 금액 보여줌
확인 누르면 register_screen 으로 넘어감


PR #9

payment_screen
결제 화면 리스트 ui 수정 : 사진 추가
상품 추가/제거에 대한 안내 추가

receipt_screen
영수증 화면과 유사하게 Ui 수정 : 시스템 구매 날짜 시간, 결제한 카드 정보 추가
뒤로가기 불가능하게 수정